### PR TITLE
Add a (now) passing test for #1637; fixed via `jackson-core` issue 33…

### DIFF
--- a/release-notes/CREDITS
+++ b/release-notes/CREDITS
@@ -664,3 +664,8 @@ Patrick Gunia (pgunia@github)
 Carsten Wickner (CarstenWickner@github)
   * Contributed #1522: Global `@JsonInclude(Include.NON_NULL)` for all properties with a specific type
    (2.9.0)
+
+Chris Plummer (strmer15@github)
+  * Reported #1637: `ObjectReader.at()` with `JsonPointer` stops after first collection
+   (2.9.0)
+

--- a/release-notes/VERSION
+++ b/release-notes/VERSION
@@ -87,6 +87,8 @@ Project: jackson-databind
  (requested by Jared J)
 #1616: Extraneous type id mapping added for base type itself
 #1619: By-pass annotation introspection for array types
+#1637: `ObjectReader.at()` with `JsonPointer` stops after first collection
+ (reported by Chris P)
 
 2.8.9 (not yet released)
 


### PR DESCRIPTION
…0 (and patch thereof)